### PR TITLE
Fix Default Color Schemes in Light & Dark Mode

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -871,7 +871,8 @@ body.theme-dark {
 /* Color Models */
 
 body.col-mod-a .theme-light,
-body.col-mod-a.theme-light {
+body.col-mod-a.theme-light,
+body.theme-light {
     --text-selection: rgb(239 206 116 / 70%);
     --text-accent: #DD9417;
     --header-col: #c66102;
@@ -925,7 +926,8 @@ body.col-mod-b.theme-light {
 }
 
 body.col-mod-c .theme-dark,
-body.col-mod-c.theme-dark {
+body.col-mod-c.theme-dark,
+body.theme-dark {
     --text-selection: rgb(208 91 41 / 70%);
     --text-accent: #FFAA1A;
     --menu-btn-color: #f2e79c;


### PR DESCRIPTION
Hi! I love this theme, it's very beautiful!

One thing I noticed is that upon installation, the colors are simple desaturated Obsidian values by default. That is because the theme relies on CSS classes for its colors, so one needs to use Style Settings to toggle those CSS classes before the colors show properly.

These changes make it so that by default, even without these Style Settings classes, the colors match the theme. So when first installed, without these classes, the colors work as intended, but when a different class is selected from Style Settings it will still work as usual.

Also, thanks for making this theme! Keep up the great work.