### PR TITLE
Remove title in embeds

### DIFF
--- a/theme.css
+++ b/theme.css
@@ -5873,6 +5873,7 @@ body .markdown-preview-view:not(.is-live-preview).hide-doc p.raisecap {
 }
 
 /* clean embed title */
+
 .markdown-embed-title
 {
     display: none;

--- a/theme.css
+++ b/theme.css
@@ -5871,3 +5871,9 @@ body .markdown-preview-view:not(.is-live-preview).hide-doc p.raisecap {
     letter-spacing: -3px;
     overflow-wrap: anywhere;
 }
+
+/* clean embed title */
+.markdown-embed-title
+{
+    display: none;
+}


### PR DESCRIPTION
At the time of embedding a note, the title of the note is displayed. 


![](https://i.imgur.com/L9LnkiM.png)

**Applied fix** 

![](https://i.imgur.com/BTo0im9.png)

In order to keep it clean, the CSS was added to make it look better at the time of exporting and generating the note. 


![](https://i.imgur.com/R4mNeYT.png)