### PR TITLE
Fix --callout-color for Obsidian 1.13+

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,6 +1,6 @@
 {
-   "name": "Dune",
-   "version": "2.6.20",
-   "minAppVersion": "1.8.0",
-   "author": "joval"
+  "name": "Dune",
+  "version": "2.6.20",
+  "minAppVersion": "1.13.0",
+  "author": "joval"
 }

--- a/theme.css
+++ b/theme.css
@@ -4692,7 +4692,7 @@ div.bases-cards-cover {
   ----------------------------------------------------------------*/
 
 .callout {
-    background-color: rgba(var(--callout-color), 0.24);
+    background-color: color-mix(in srgb, var(--callout-color) 24%, transparent);
     mix-blend-mode: normal;
 }
 
@@ -4847,7 +4847,7 @@ div[data-callout="multi-column"].callout>.callout-content>*:is(div, ul) {
     div[data-callout="mehrspaltig"].callout>div.callout-content .callout.is-collapsed .callout-title,
     div[data-callout="multi-column"].callout>div.callout-content .callout.is-collapsed .callout-title {
         border-top-left-radius: 2px;
-        background-color: rgba(var(--callout-color), 0.1);
+        background-color: color-mix(in srgb, var(--callout-color) 10%, transparent);
         padding: inherit;
         border-radius: 4px;
     }


### PR DESCRIPTION
Hello! I'm [saberzero1](https://github.com/saberzero1), a [community reviewer](https://obsidian.md/help/credits#Community+review) for Obsidian plugins and themes. We're sending this PR out to you proactively to help you prepare for a recent Obsidian update.

## Summary

Obsidian 1.13 changed how `--callout-color` works. It now provides a valid CSS color value (e.g. `rgb(255, 0, 128)`) instead of a bare RGB triplet (`255, 0, 128`).

This breaks two patterns:

**1. Bare RGB triplets in declarations:**
```css
/* Before (broken on 1.13+) */
--callout-color: 255, 0, 128;
/* After */
--callout-color: rgb(255, 0, 128);
```

**2. Wrapping `var(--callout-color)` in `rgb()`/`rgba()`:**
```css
/* Before (produces invalid rgb(rgb(...)) on 1.13+) */
background: rgba(var(--callout-color), 0.1);
/* After */
background: color-mix(in srgb, var(--callout-color) 10%, transparent);
```

## Changes

- Wrapped bare RGB triplets in `--callout-color` declarations with `rgb()`
- Replaced `rgb(var(--callout-color))` with `var(--callout-color)`
- Replaced `rgba(var(--callout-color), <alpha>)` with `color-mix(in srgb, var(--callout-color) <percent>, transparent)`
- Updated `minAppVersion` in `manifest.json` to `1.13.0` (if it was lower)

## Context

See the [Obsidian 1.13 changelog](https://obsidian.md/changelog/) for details on this breaking change.
